### PR TITLE
Fix typo in trailing line which prevented package installation

### DIFF
--- a/glsl-mode.el
+++ b/glsl-mode.el
@@ -295,4 +295,4 @@
 ;(easy-menu-define c-glsl-menu glsl-mode-map "GLSL Mode Commands"
 ;		  (cons "GLSL" (c-lang-const c-mode-menu glsl)))
 
-;;; glsls-mode.el ends here
+;;; glsl-mode.el ends here


### PR DESCRIPTION
The small typo in the trailing line broke `package-buffer-info` and hence installation of this library via the `package.el` mechanisms.

(Background: we are building packages of `glsl-mode` over at [MELPA](http://melpa.milkbox.net/) but it turns out they haven't been installable due to this minor error.)
