### PR TITLE
Fix invalid face: quote error during htmlize

### DIFF
--- a/glsl-mode.el
+++ b/glsl-mode.el
@@ -77,42 +77,42 @@
 
 (defvar glsl-type-face 'glsl-type-face)
 (defface glsl-type-face
-  '((t (:inherit 'font-lock-type-face))) "glsl: type face"
+  '((t (:inherit font-lock-type-face))) "glsl: type face"
   :group 'glsl)
 
 (defvar glsl-builtin-face 'glsl-builtin-face)
 (defface glsl-builtin-face
-  '((t (:inherit 'font-lock-builtin-face))) "glsl: builtin face"
+  '((t (:inherit font-lock-builtin-face))) "glsl: builtin face"
   :group 'glsl)
 
 (defvar glsl-deprecated-builtin-face 'glsl-deprecated-builtin-face)
 (defface glsl-deprecated-builtin-face
-  '((t (:inherit 'glsl-builtin-face))) "glsl: deprecated builtin face"
+  '((t (:inherit glsl-builtin-face))) "glsl: deprecated builtin face"
   :group 'glsl)
 
 (defvar glsl-keyword-face 'glsl-keyword-face)
 (defface glsl-keyword-face
-  '((t (:inherit 'font-lock-keyword-face))) "glsl: keyword face"
+  '((t (:inherit font-lock-keyword-face))) "glsl: keyword face"
   :group 'glsl)
 
 (defvar glsl-deprecated-keyword-face 'glsl-deprecated-keyword-face)
 (defface glsl-deprecated-keyword-face
-  '((t (:inherit 'glsl-keyword-face))) "glsl: deprecated keyword face"
+  '((t (:inherit glsl-keyword-face))) "glsl: deprecated keyword face"
   :group 'glsl)
 
 (defvar glsl-variable-name-face 'glsl-variable-name-face)
 (defface glsl-variable-name-face
-  '((t (:inherit 'font-lock-variable-name-face))) "glsl: variable face"
+  '((t (:inherit font-lock-variable-name-face))) "glsl: variable face"
   :group 'glsl)
 
 (defvar glsl-deprecated-variable-name-face 'glsl-deprecated-variable-name-face)
 (defface glsl-deprecated-variable-name-face
-  '((t (:inherit 'glsl-variable-name-face))) "glsl: deprecated variable face"
+  '((t (:inherit glsl-variable-name-face))) "glsl: deprecated variable face"
   :group 'glsl)
 
 (defvar glsl-preprocessor-face 'glsl-preprocessor-face)
 (defface glsl-preprocessor-face
-  '((t (:inherit 'font-lock-preprocessor-face))) "glsl: preprocessor face"
+  '((t (:inherit font-lock-preprocessor-face))) "glsl: preprocessor face"
   :group 'glsl)
 
 (defvar glsl-mode-hook nil)


### PR DESCRIPTION
Whenever I tried to htmlize any GLSL code, I would be greeted with the
"invalid face: quote" error.  Fortunately, this same error was also
diagnosed and fixed for php-mode:
https://www.reddit.com/r/emacs/comments/2teinj/help_with_an_error_invalid_face_quote_when_using/

I have applied the same fix to the glsl-mode.el code.