### PR TITLE
glsl-ts-mode improvements

### DIFF
--- a/glsl-db.el
+++ b/glsl-db.el
@@ -29,6 +29,11 @@
 
 ;;; Code:
 
+(defvar glsl-operator-list
+  '("=" "-" "*" "/" "+" "%" "|" "&" "^" "<<" ">>" "." "<"
+    "<=" ">=" ">" "==" "!=" "!" "&&" "||" "-=" "+=" "*=" "/="
+    "%=" "|=" "&=" "^=" ">>=" "<<=" "--" "++"))
+
 (defvar glsl-type-list
   '("float" "double" "int" "void" "bool" "mat2" "mat3"
     "mat4" "dmat2" "dmat3" "dmat4" "mat2x2" "mat2x3" "mat2x4" "dmat2x2"

--- a/glsl-mode.el
+++ b/glsl-mode.el
@@ -302,7 +302,9 @@ the appropriate place for that."
 
 (defvar glsl-other-file-alist
   '(("\\.frag$" (".vert"))
-    ("\\.vert$" (".frag")))
+    ("\\.vert$" (".frag"))
+    ("\\.frag.glsl$" (".vert.glsl"))
+    ("\\.vert.glsl$" (".frag.glsl")))
   "Alist of extensions to find given the current file's extension.")
 
 (defun glsl-man-completion-list ()

--- a/glsl-mode.el
+++ b/glsl-mode.el
@@ -87,7 +87,7 @@
 
 (defvar glsl-shader-variable-name-face 'glsl-shader-variable-name-face)
 (defface glsl-shader-variable-name-face
-  '((t (:inherit font-lock-preprocessor-face :slant italic)))
+  '((t (:inherit font-lock-variable-name-face :weight bold)))
   "GLSL type face."
   :group 'glsl)
 

--- a/glsl-mode.el
+++ b/glsl-mode.el
@@ -202,7 +202,7 @@ the `glsl-builtins-face'."
 (defcustom glsl-browse-url-function #'browse-url
   "Function used to display GLSL man pages.
 
-E.g. the function used by calls to 'browse-url', eww, w3m, etc."
+E.g. the function used by calls to `browse-url', eww, w3m, etc."
   :type 'function
   :group 'glsl)
 

--- a/glsl-mode.el
+++ b/glsl-mode.el
@@ -87,7 +87,7 @@
 
 (defvar glsl-shader-variable-name-face 'glsl-shader-variable-name-face)
 (defface glsl-shader-variable-name-face
-  '((t (:inherit font-lock-variable-name-face :weight bold)))
+  '((t (:inherit font-lock-preprocessor-face :slant italic)))
   "GLSL type face."
   :group 'glsl)
 

--- a/glsl-ts-mode.el
+++ b/glsl-ts-mode.el
@@ -64,7 +64,7 @@
   (set-default sym val)
   (dolist (buffer (buffer-list))
     (with-current-buffer buffer
-      (when (derived-mode-p '(glsl-ts-mode))
+      (when (derived-mode-p 'glsl-ts-mode)
         (glsl-ts--apply-indent-rules val)))))
 
 (defcustom glsl-ts-indent-style nil

--- a/glsl-ts-mode.el
+++ b/glsl-ts-mode.el
@@ -6,7 +6,7 @@
 ;; Keywords: languages OpenGL GPU SPIR-V Vulkan
 ;; Version: 1.0
 ;; URL: https://github.com/jimhourihan/glsl-mode
-;; Package-Requires: ((emacs "29"))
+;; Package-Requires: ((emacs "29.4"))
 ;;
 
 ;; This file is free software; you can redistribute it and/or modify
@@ -337,9 +337,12 @@ This style is passed directly to the "
       (treesit-major-mode-setup))))
 
 (when (treesit-ready-p 'glsl)
-  (setq major-mode-remap-defaults
-        (assq-delete-all 'glsl-mode major-mode-remap-defaults))
-  (add-to-list 'major-mode-remap-defaults '(glsl-mode . glsl-ts-mode)))
+  (let ((remap-alist (if (< emacs-major-version 30)
+                         'major-mode-remap-alist
+                         'major-mode-remap-defaults)))
+    (set remap-alist
+         (assq-delete-all 'glsl-mode (eval remap-alist)))
+    (add-to-list remap-alist '(glsl-mode . glsl-ts-mode))))
 
 (provide 'glsl-ts-mode)
 

--- a/glsl-ts-mode.el
+++ b/glsl-ts-mode.el
@@ -290,37 +290,6 @@ This style is passed directly to the "
   "Regular expression used to navigate to the next defun.")
 
 
-(defun glsl-ts-setup ()
-  "Setup treesitter for glsl-ts-mode."
-
-  ;; Syntax-highlighting.
-  (setq-local treesit-font-lock-settings
-              (apply #'treesit-font-lock-rules
-                     (glsl-ts-font-lock-rules glsl-ts-buffer-shader-type)))
-
-  ;; Indentation.
-  (setq-local treesit-simple-indent-rules
-              (treesit--indent-rules-optimize
-               (c-ts-mode--simple-indent-rules 'c c-ts-mode-indent-style)))
-
-  (setq-local c-ts-mode-indent-offset glsl-indent-offset)
-
-  ;; Navigation
-  (setq-local treesit-defun-type-regexp glsl-ts--defun-navigation-regexp)
-  (setq-local treesit-defun-skipper #'c-ts-mode--defun-skipper)
-  (setq-local treesit-defun-name-function #'c-ts-mode--defun-name)
-
-  ;; Nodes like struct/enum/union_specifier can appear in
-  ;; function_definitions, so we need to find the top-level node.
-  (setq-local treesit-defun-prefer-top-level t)
-  (setq-local treesit-defun-tactic 'top-level)
-
-  ;; IMenu.
-  (setq-local treesit-simple-imenu-settings glsl-ts--imenu-rules)
-
-  (treesit-major-mode-setup))
-
-
 (defvar-keymap glsl-ts-mode-map
   :doc "Keymap for GLSL."
   :parent prog-mode-map)
@@ -338,17 +307,6 @@ This style is passed directly to the "
       ;; Find-file.
       (setq-local ff-other-file-alist 'glsl-other-file-alist)
 
-      ;; Comment.
-      (c-ts-common-comment-setup)
-      (setq-local comment-start "/* ")
-      (setq-local comment-end " */")
-
-      ;; Electric
-      (setq-local electric-indent-chars (append "{}():;,#" electric-indent-chars))
-
-      ;; Align.
-      (add-to-list 'align-c++-modes 'glsl-ts-mode)
-
       ;; Font-lock settings.
       (setq-local font-lock-defaults nil)
       (setq-local treesit-font-lock-feature-list
@@ -357,7 +315,19 @@ This style is passed directly to the "
                     (assignment constant escape-sequence literal)
                     (bracket delimiter error function operator property variable)))
 
-      (glsl-ts-setup))))
+      ;; Syntax-highlighting.
+      (setq-local treesit-font-lock-settings
+                  (apply #'treesit-font-lock-rules
+                         (glsl-ts-font-lock-rules glsl-ts-buffer-shader-type)))
+
+      ;; Indentation.
+      (setq-local treesit-simple-indent-rules
+                  (c-ts-mode--simple-indent-rules
+                   'c c-ts-mode-indent-style))
+      (setcar (car treesit-simple-indent-rules) 'glsl)
+      (setq-local c-ts-common-indent-offset 'glsl-indent-offset)
+
+      (treesit-major-mode-setup))))
 
 (when (treesit-ready-p 'glsl)
   (setq major-mode-remap-defaults

--- a/glsl-ts-mode.el
+++ b/glsl-ts-mode.el
@@ -303,7 +303,9 @@ This style is passed directly to the "
 (define-derived-mode glsl-ts-mode c-ts-base-mode "GLSL"
   "Major mode for editing GLSL shaders with tree-sitter."
 
-  (when (treesit-ensure-installed 'glsl)
+  (when (if (< emacs-major-version 31)
+            (treesit-ready-p 'glsl)
+            (treesit-ensure-installed 'glsl))
     (let ((primary-parser (treesit-parser-create 'glsl)))
 
       (setq-local glsl-ts-buffer-shader-type (glsl-ts--detect-shader-type))
@@ -326,8 +328,9 @@ This style is passed directly to the "
 
       ;; Indentation.
       (setq-local treesit-simple-indent-rules
-                  (c-ts-mode--simple-indent-rules
-                   'c c-ts-mode-indent-style))
+                  (if (< emacs-major-version 31)
+                      (c-ts-mode--get-indent-style 'c)
+                      (c-ts-mode--simple-indent-rules 'c c-ts-mode-indent-style)))
       (setcar (car treesit-simple-indent-rules) 'glsl)
       (setq-local c-ts-common-indent-offset 'glsl-indent-offset)
 

--- a/glsl-ts-mode.el
+++ b/glsl-ts-mode.el
@@ -202,6 +202,10 @@ This style is passed directly to the "
               @font-lock-builtin-face)))
 
     :language glsl
+    :feature function
+    ((call_expression function: (identifier) @font-lock-function-call-face))
+
+    :language glsl
     :feature qualifier
     (((type_qualifier) @font-lock-keyword-face))
 

--- a/glsl-ts-mode.el
+++ b/glsl-ts-mode.el
@@ -188,6 +188,9 @@ This style is passed directly to the "
                             type: (_) declarator: (identifier) @font-lock-variable-name-face)
      (array_declarator declarator: (identifier) @font-lock-variable-name-face)
      (call_expression function:
+                      ((subscript_expression argument: (identifier) @font-lock-type-face)
+                       (:match ,(rx-to-string `(seq bol (or ,@glsl-type-list) eol)) @font-lock-type-face)))
+     (call_expression function:
                       ((identifier) @font-lock-type-face
                        (:match ,(rx-to-string `(seq bol (or ,@glsl-type-list) eol)) @font-lock-type-face))))
 

--- a/glsl-ts-mode.el
+++ b/glsl-ts-mode.el
@@ -88,9 +88,8 @@ Alternatively, set it to `nil' to inherit from `c-ts-mode-indent-style'."
                                   (c-ts-mode--simple-indent-rules 'c c-ts-mode-indent-style)))
   (setcar (car treesit-simple-indent-rules) 'glsl))
 
-;; TODO: Add Keyword "discard" to GLSL grammar.
 (defvar glsl-ts-keywords
-  '("break" "continue" "do" "for" "while" "if" "else" ;; "discard"
+  '("break" "continue" "do" "for" "while" "if" "else"
     "subroutine" "return" "switch" "default" "case")
   "Keywords that shoud be high-lighted.")
 
@@ -219,7 +218,9 @@ Alternatively, set it to `nil' to inherit from `c-ts-mode-indent-style'."
 
     :language glsl
     :feature keyword
-    ([,@glsl-ts-keywords] @font-lock-keyword-face)
+    ((expression_statement (identifier) @font-lock-keyword-face
+                           (:match "discard" @font-lock-keyword-face))
+     [,@glsl-ts-keywords] @font-lock-keyword-face)
 
     :language glsl
     :feature builtin

--- a/glsl-ts-mode.el
+++ b/glsl-ts-mode.el
@@ -224,7 +224,8 @@ Alternatively, set it to `nil' to inherit from `c-ts-mode-indent-style'."
 
     :language glsl
     :feature keyword
-    ((expression_statement (identifier) @font-lock-keyword-face
+    ((conditional_expression (["?" ":"]) @font-lock-keyword-face)
+     (expression_statement (identifier) @font-lock-keyword-face
                            (:match "discard" @font-lock-keyword-face))
      [,@glsl-ts-keywords] @font-lock-keyword-face)
 

--- a/glsl-ts-mode.el
+++ b/glsl-ts-mode.el
@@ -83,9 +83,9 @@ Alternatively, set it to `nil' to inherit from `c-ts-mode-indent-style'."
 (defun glsl-ts--apply-indent-rules (style)
   (setq-local c-ts-mode-indent-style (or style c-ts-mode-indent-style))
   (setq-local treesit-simple-indent-rules
-              (glsl-ts--static-if (< emacs-major-version 31)
-                                  (c-ts-mode--get-indent-style 'c)
-                                  (c-ts-mode--simple-indent-rules 'c c-ts-mode-indent-style)))
+              (glsl-ts--static-if (version<= emacs-version "30.1")
+                                  (c-ts-mode--simple-indent-rules 'c c-ts-mode-indent-style)
+                                  (c-ts-mode--get-indent-style 'c)))
   (setcar (car treesit-simple-indent-rules) 'glsl))
 
 (defvar glsl-ts-keywords

--- a/glsl-ts-mode.el
+++ b/glsl-ts-mode.el
@@ -196,6 +196,7 @@ Alternatively, set it to `nil' to inherit from `c-ts-mode-indent-style'."
     ((function_declarator declarator: (_) @font-lock-function-name-face)
      (struct_specifier "struct" @font-lock-keyword-face)
      (declaration "uniform" @font-lock-keyword-face)
+     (declaration "shared" @font-lock-keyword-face)
      (declaration (layout_specification "layout" @glsl-qualifier-face)
                   [,@glsl-qualifier-list] @font-lock-keyword-face
                   (identifier) @font-lock-variable-name-face)

--- a/glsl-ts-mode.el
+++ b/glsl-ts-mode.el
@@ -33,7 +33,13 @@
 (require 'c-ts-mode)
 (require 'glsl-mode)
 
+(add-to-list
+ 'treesit-language-source-alist
+ '(glsl "https://github.com/tree-sitter-grammars/tree-sitter-glsl"
+        :commit "24a6c8ef698e4480fecf8340d771fbcb5de8fbb4")
+ t)
 
+;;;###autoload
 (defmacro glsl-ts--static-if (condition then-form &rest else-forms)
   (declare (indent 2)
            (debug (sexp sexp &rest sexp)))
@@ -305,10 +311,15 @@ Alternatively, set it to `nil' to inherit from `c-ts-mode-indent-style'."
 
 ;;;###autoload
 (define-derived-mode glsl-ts-mode c-ts-base-mode "GLSL"
-  "Major mode for editing GLSL shaders with tree-sitter."
+  "Major mode for editing GLSL, powered by tree-sitter.
+
+Since this mode uses a parser, unbalanced brackets might cause
+some breakage in indentation/fontification.  Therefore, it's
+recommended to enable `electric-pair-mode' with this mode."
+  :group 'glsl
 
   (when (glsl-ts--static-if (< emacs-major-version 31)
-                            (treesit-ready-p 'glsl)
+                            (treesit-ready-p 'glsl t)
                             (treesit-ensure-installed 'glsl))
 
     (treesit-parser-create 'glsl)
@@ -337,13 +348,9 @@ Alternatively, set it to `nil' to inherit from `c-ts-mode-indent-style'."
     
     (treesit-major-mode-setup)))
 
-(when (treesit-ready-p 'glsl)
-  (let ((remap-alist (glsl-ts--static-if (< emacs-major-version 30)
-                                         'major-mode-remap-alist
-                                         'major-mode-remap-defaults)))
-    (set remap-alist
-         (assq-delete-all 'glsl-mode (eval remap-alist)))
-    (add-to-list remap-alist '(glsl-mode . glsl-ts-mode))))
+;;;###autoload
+(when (treesit-ready-p 'glsl t)
+  (add-to-list 'major-mode-remap-alist '(glsl-mode . glsl-ts-mode)))
 
 (provide 'glsl-ts-mode)
 

--- a/glsl-ts-mode.el
+++ b/glsl-ts-mode.el
@@ -346,20 +346,9 @@ recommended to enable `electric-pair-mode' with this mode."
     (progn
       (when (treesit-ready-p 'glsl t)
         (add-to-list 'major-mode-remap-alist '(glsl-mode . glsl-ts-mode))))
-  (progn
-    (defun glsl-ts-mode-maybe ()
-      "Enable `glsl-ts-mode' when its grammar is available.
-    Also propose to install the grammar when `treesit-enabled-modes'
-    is t or contains the mode name."
-      (declare-function treesit-language-available-p "treesit.c")
-      (if (or (treesit-language-available-p 'cmake)
-              (eq treesit-enabled-modes t)
-              (memq 'glsl-ts-mode treesit-enabled-modes))
-          (glsl-ts-mode)
-        (fundamental-mode)))
-    (when (boundp 'treesit-major-mode-remap-alist)
-      (add-to-list 'treesit-major-mode-remap-alist
-               '(glsl-mode . glsl-ts-mode-maybe)))))
+    (progn
+      (when (boundp 'treesit-major-mode-remap-alist)
+        (add-to-list 'treesit-major-mode-remap-alist '(glsl-mode . glsl-ts-mode)))))
 
 (provide 'glsl-ts-mode)
 

--- a/glsl-ts-mode.el
+++ b/glsl-ts-mode.el
@@ -83,9 +83,9 @@ Alternatively, set it to `nil' to inherit from `c-ts-mode-indent-style'."
 (defun glsl-ts--apply-indent-rules (style)
   (setq-local c-ts-mode-indent-style (or style c-ts-mode-indent-style))
   (setq-local treesit-simple-indent-rules
-              (glsl-ts--static-if (version<= emacs-version "30.1")
-                                  (c-ts-mode--simple-indent-rules 'c c-ts-mode-indent-style)
-                                  (c-ts-mode--get-indent-style 'c)))
+              (glsl-ts--static-if (< emacs-major-version 31)
+                                  (c-ts-mode--get-indent-style 'c)
+                                  (c-ts-mode--simple-indent-rules 'c c-ts-mode-indent-style)))
   (setcar (car treesit-simple-indent-rules) 'glsl))
 
 (defvar glsl-ts-keywords

--- a/glsl-ts-mode.el
+++ b/glsl-ts-mode.el
@@ -35,8 +35,7 @@
 
 (add-to-list
  'treesit-language-source-alist
- '(glsl "https://github.com/tree-sitter-grammars/tree-sitter-glsl"
-        :commit "24a6c8ef698e4480fecf8340d771fbcb5de8fbb4")
+ '(glsl "https://github.com/tree-sitter-grammars/tree-sitter-glsl")
  t)
 
 ;;;###autoload
@@ -46,7 +45,6 @@
   (if (eval condition lexical-binding)
       then-form
     (cons 'progn else-forms)))
-
 
 (defcustom glsl-ts-all-shader-variables t
   "Always highlight all shader variables."
@@ -98,7 +96,6 @@ Alternatively, set it to `nil' to inherit from `c-ts-mode-indent-style'."
   '("break" "continue" "do" "for" "while" "if" "else"
     "subroutine" "return" "switch" "default" "case")
   "Keywords that shoud be high-lighted.")
-
 
 (defun glsl-ts--shader-constants (shader-type)
   "Create a list of special variables and constants for SHADER-TYPE."
@@ -278,10 +275,8 @@ Alternatively, set it to `nil' to inherit from `c-ts-mode-indent-style'."
     :feature bracket
     (["(" ")" "{" "}" "[" "]"] @font-lock-bracket-face)))
 
-
 (defvar glsl-ts-buffer-shader-type nil
   "The current buffer shader-type.")
-
 
 (defun glsl-ts--detect-shader-type ()
   "Attempt to detect which GLSL shader type is active in the current buffer."
@@ -303,11 +298,9 @@ Alternatively, set it to `nil' to inherit from `c-ts-mode-indent-style'."
     ((or "glsl") nil)
     (_ nil)))
 
-
 (defvar-keymap glsl-ts-mode-map
   :doc "Keymap for GLSL."
   :parent prog-mode-map)
-
 
 ;;;###autoload
 (define-derived-mode glsl-ts-mode c-ts-base-mode "GLSL"
@@ -349,8 +342,24 @@ recommended to enable `electric-pair-mode' with this mode."
     (treesit-major-mode-setup)))
 
 ;;;###autoload
-(when (treesit-ready-p 'glsl t)
-  (add-to-list 'major-mode-remap-alist '(glsl-mode . glsl-ts-mode)))
+(glsl-ts--static-if (< emacs-major-version 31)
+    (progn
+      (when (treesit-ready-p 'glsl t)
+        (add-to-list 'major-mode-remap-alist '(glsl-mode . glsl-ts-mode))))
+  (progn
+    (defun glsl-ts-mode-maybe ()
+      "Enable `glsl-ts-mode' when its grammar is available.
+    Also propose to install the grammar when `treesit-enabled-modes'
+    is t or contains the mode name."
+      (declare-function treesit-language-available-p "treesit.c")
+      (if (or (treesit-language-available-p 'cmake)
+              (eq treesit-enabled-modes t)
+              (memq 'glsl-ts-mode treesit-enabled-modes))
+          (glsl-ts-mode)
+        (fundamental-mode)))
+    (when (boundp 'treesit-major-mode-remap-alist)
+      (add-to-list 'treesit-major-mode-remap-alist
+               '(glsl-mode . glsl-ts-mode-maybe)))))
 
 (provide 'glsl-ts-mode)
 

--- a/glsl-ts-mode.el
+++ b/glsl-ts-mode.el
@@ -166,22 +166,16 @@ Alternatively, set it to `nil' to inherit from `c-ts-mode-indent-style'."
     ;; extension specifications.
     ((preproc_call (preproc_directive) @glsl-preprocessor-face
                    ((preproc_arg) @glsl-extension-face))
-     (preproc_if "#if" @glsl-preprocessor-face
-                    name: (identifier) @font-lock-constant-face)
-     (preproc_ifdef "#ifdef" @glsl-preprocessor-face
-                    name: (identifier) @font-lock-constant-face)
-     (preproc_elif "#elif" @glsl-preprocessor-face
-                    name: (identifier) @font-lock-constant-face)
-     (preproc_ifdef "#ifndef" @glsl-preprocessor-face
-                    name: (identifier) @font-lock-constant-face)
-     (preproc_else "#else" @glsl-preprocessor-face)
-     (["#endif"] @glsl-preprocessor-face)
-     (preproc_def "#define" @glsl-preprocessor-face
-                  name: (identifier) @font-lock-variable-name-face)
-     (preproc_function_def "#define" @glsl-preprocessor-face
-                           name: ((identifier) @font-lock-function-name-face))
-     (preproc_include "#include" @glsl-preprocessor-face
-                      ((string_literal) @font-lock-string-face))
+     (preproc_if (identifier) @font-lock-constant-face)
+     (preproc_if condition: (_ (identifier) @font-lock-constant-face))
+     (preproc_elif (identifier) @font-lock-constant-face)
+     (preproc_elif condition: (_ (identifier) @font-lock-constant-face))
+     (preproc_ifdef name: (identifier) @font-lock-constant-face)
+     (preproc_def name: (identifier) @font-lock-constant-face)
+     (preproc_function_def name: ((identifier) @font-lock-function-name-face))
+     (preproc_include ((string_literal) @font-lock-string-face))
+     (["#if", "#ifdef", "#ifndef", "#else", "#elif", "#endif", "#define", "#include"]
+      @glsl-preprocessor-face)
      (preproc_extension (preproc_directive) @glsl-preprocessor-face
                         extension: (identifier) @glsl-extension-face
                         ((extension_behavior) @font-lock-keyword-face

--- a/glsl-ts-mode.el
+++ b/glsl-ts-mode.el
@@ -166,11 +166,18 @@ Alternatively, set it to `nil' to inherit from `c-ts-mode-indent-style'."
     ;; extension specifications.
     ((preproc_call (preproc_directive) @glsl-preprocessor-face
                    ((preproc_arg) @glsl-extension-face))
+     (preproc_if "#if" @glsl-preprocessor-face
+                    name: (identifier) @font-lock-constant-face)
+     (preproc_ifdef "#ifdef" @glsl-preprocessor-face
+                    name: (identifier) @font-lock-constant-face)
+     (preproc_elif "#elif" @glsl-preprocessor-face
+                    name: (identifier) @font-lock-constant-face)
      (preproc_ifdef "#ifndef" @glsl-preprocessor-face
-                    name: ((identifier) @font-lock-variable-name-face))
+                    name: (identifier) @font-lock-constant-face)
+     (preproc_else "#else" @glsl-preprocessor-face)
      (["#endif"] @glsl-preprocessor-face)
      (preproc_def "#define" @glsl-preprocessor-face
-                  name: ((identifier) @font-lock-variable-name-face))
+                  name: (identifier) @font-lock-variable-name-face)
      (preproc_function_def "#define" @glsl-preprocessor-face
                            name: ((identifier) @font-lock-function-name-face))
      (preproc_include "#include" @glsl-preprocessor-face

--- a/glsl-ts-mode.el
+++ b/glsl-ts-mode.el
@@ -195,6 +195,7 @@ Alternatively, set it to `nil' to inherit from `c-ts-mode-indent-style'."
     :feature definition
     ((function_declarator declarator: (_) @font-lock-function-name-face)
      (struct_specifier "struct" @font-lock-keyword-face)
+     (declaration "uniform" @font-lock-keyword-face)
      (declaration (layout_specification "layout" @glsl-qualifier-face)
                   [,@glsl-qualifier-list] @font-lock-keyword-face
                   (identifier) @font-lock-variable-name-face)


### PR DESCRIPTION
Changes to `glsl-ts-mode.el`:
 * Inherit from c-ts-base-mode (fixes `eglot` issues!)
 * Indentation code takes Emacs version into account and decides on which API to use via `static-if`. Still ugly since it uses private functions but it should work.
 * Improved qualifiers (use existing list from `glsl-db.el`)
 * Improved preproc_* highlighting
 * Added function call highlighting
 * Added support for delimiters
 * Added support for properties
 * Added support for operators
 * Mode setup is updated to match current `*-ts-mode` conventions. If `treesit` is available then map `glsl-mode` to `glsl-ts-mode`.

Additionally:
 * `other-file` rules to cycle between `*.frag.glsl` and `*.vert.glsl` files
 * Fixed compilation warning due to bad quoting in `glsl-browse-url-function` docstring