### PR TITLE
Fix #20: Eternal loop on an unbalanced brace

### DIFF
--- a/glsl-mode.el
+++ b/glsl-mode.el
@@ -357,6 +357,11 @@ the appropriate place for that."
 		     (c-update-modeline))
   (c-initialize-cc-mode t)
   (c-init-language-vars glsl-mode)
+  ;; Let CC Mode's `syntax-table' props take effect
+  ;; (it isn't auto-enabled for glsl-mode), otherwise
+  ;; `c-neutralize-CPP-line' loops forever on a `#define'
+  ;; line with an unbalanced brace, see #20.
+  (setq-local parse-sexp-lookup-properties t)
   (c-common-init 'glsl-mode)
   (cc-imenu-init cc-imenu-c++-generic-expression)
 

--- a/glsl-mode.el
+++ b/glsl-mode.el
@@ -357,10 +357,6 @@ the appropriate place for that."
 		     (c-update-modeline))
   (c-initialize-cc-mode t)
   (c-init-language-vars glsl-mode)
-  ;; Let CC Mode's `syntax-table' props take effect
-  ;; (it isn't auto-enabled for glsl-mode), otherwise
-  ;; `c-neutralize-CPP-line' loops forever on a `#define'
-  ;; line with an unbalanced brace, see #20.
   (setq-local parse-sexp-lookup-properties t)
   (c-common-init 'glsl-mode)
   (cc-imenu-init cc-imenu-c++-generic-expression)


### PR DESCRIPTION
Enabling glsl-mode on a buffer containing a C preprocessor macro line with an unbalanced paren/brace, for e.g. a single diff hunk cut from the middle of a multi-line `#define' -- hangs Emacs in an uninterruptible loop during mode setup (in `c-neutralize-CPP-line', via `c-common-init').

Fix by enabling enable `parse-sexp-lookup-properties' in the glsl-mode body, which `c-basic-common-init' notes external modes may enable.

This is likely the better tested code-path as major built-in C modes use this.